### PR TITLE
friend class definetion shouldnt contain default arguments

### DIFF
--- a/include/rgbd/Image.h
+++ b/include/rgbd/Image.h
@@ -84,8 +84,8 @@ public:
     }
 
     friend bool serialize(const Image& image, tue::serialization::OutputArchive& a,
-                          RGBStorageType rgb_type = RGB_STORAGE_JPG,
-                          DepthStorageType depth_type = DEPTH_STORAGE_PNG);
+                          RGBStorageType rgb_type,
+                          DepthStorageType depth_type);
 
     friend bool deserialize(tue::serialization::InputArchive& a, Image& image);
 

--- a/include/rgbd/serialization.h
+++ b/include/rgbd/serialization.h
@@ -14,8 +14,8 @@ class Image;
 // SERIALIZATION
 
 bool serialize(const Image& image, tue::serialization::OutputArchive& a,
-               RGBStorageType rgb_type,
-               DepthStorageType depth_type);
+               RGBStorageType rgb_type = RGB_STORAGE_JPG,
+               DepthStorageType depth_type = DEPTH_STORAGE_PNG);
 
 // DESERIALIZATION
 


### PR DESCRIPTION
This marked by QTcreator. Moving the default arguments to the non friend declaration.