### PR TITLE
Fix Shared Memory server + small cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,9 @@ add_library(rgbd    src/Server.cpp
                     ${HEADER_FILES})
 target_link_libraries(rgbd ${catkin_LIBRARIES} rt)
 
+# compile the library after messages have been generated
+add_dependencies(rgbd ${${PROJECT_NAME}_EXPORTED_TARGETS})
+
 # - - - - - - - - - - - - - - - - - TOOLS - - - - - - - - - - - - - - - - -
 
 add_executable(rgbd_server src/server.cpp)
@@ -89,9 +92,6 @@ target_link_libraries(rgbd_save rgbd)
 
 add_executable(rgbd_view src/view.cpp)
 target_link_libraries(rgbd_view rgbd)
-
-# compile the library after messages have been generated
-add_dependencies(rgbd ${PROJECT_NAME}_generate_messages_cpp)
 
 add_executable(record_to_video tools/record_to_video.cpp)
 target_link_libraries(record_to_video rgbd)

--- a/include/rgbd/Client.h
+++ b/include/rgbd/Client.h
@@ -37,6 +37,10 @@ public:
 
     virtual ~Client();
 
+    /**
+     * @brief intialize Initialize the client
+     * @param server_name Fully resolved server name
+     */
     void intialize(const std::string& server_name);
 
     void intialize(const std::string& rgb_image_topic, const std::string& depth_image_topic, const std::string& cam_info_topic);

--- a/include/rgbd/Server.h
+++ b/include/rgbd/Server.h
@@ -24,6 +24,12 @@ public:
 
     virtual ~Server();
 
+    /**
+     * @brief initialize initialize server
+     * @param name Fully resolved server name
+     * @param rgb_type
+     * @param depth_type
+     */
     void initialize(const std::string& name, RGBStorageType rgb_type = RGB_STORAGE_LOSSLESS, DepthStorageType depth_type = DEPTH_STORAGE_LOSSLESS);
 
     void send(const Image& image, bool threaded = false);

--- a/include/rgbd/shared_mem_client.h
+++ b/include/rgbd/shared_mem_client.h
@@ -22,9 +22,10 @@ public:
     /**
      * @brief intialize Initialize shared memory client
      * @param server_name Fully resolved server name
+     * @param timeout Timeout to wait for shared memory server
      * @return indicates success
      */
-    bool intialize(const std::string& server_name);
+    bool intialize(const std::string& server_name, float timeout = 5.0);
 
     bool initialized();
 

--- a/include/rgbd/shared_mem_client.h
+++ b/include/rgbd/shared_mem_client.h
@@ -19,6 +19,11 @@ public:
 
     ~SharedMemClient();
 
+    /**
+     * @brief intialize Initialize shared memory client
+     * @param server_name Fully resolved server name
+     * @return indicates success
+     */
     bool intialize(const std::string& server_name);
 
     bool initialized();

--- a/include/rgbd/shared_mem_client.h
+++ b/include/rgbd/shared_mem_client.h
@@ -32,7 +32,7 @@ private:
     boost::interprocess::mapped_region mem_buffer_header;
     boost::interprocess::mapped_region mem_image;
 
-    int sequence_nr;
+    uint64_t sequence_nr;
 
     BufferHeader* buffer_header;
 

--- a/include/rgbd/shared_mem_server.h
+++ b/include/rgbd/shared_mem_server.h
@@ -19,6 +19,10 @@ public:
 
     ~SharedMemServer();
 
+    /**
+     * @brief initialize Initialize shared memory server
+     * @param name Fully resolved server name
+     */
     void initialize(const std::string& name);
 
     void send(const Image& image);

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -110,9 +110,11 @@ bool Client::nextImage(Image& image)
 ImagePtr Client::nextImage() {
     if (shared_mem_client_.initialized())
     {
-        ImagePtr img;
-        shared_mem_client_.nextImage(*img);
+        ImagePtr img(new Image); // TODO
+        if (shared_mem_client_.nextImage(*img))
             return img;
+        else
+            return ImagePtr();
     }
 
     image_ptr_ = nullptr;

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -111,10 +111,8 @@ ImagePtr Client::nextImage() {
     if (shared_mem_client_.initialized())
     {
         ImagePtr img;
-        if (shared_mem_client_.nextImage(*img))
+        shared_mem_client_.nextImage(*img);
             return img;
-        else
-            return ImagePtr();
     }
 
     image_ptr_ = nullptr;

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -189,7 +189,6 @@ void Client::camInfoCallback(const sensor_msgs::CameraInfoConstPtr& cam_info_msg
 }
 
 // ----------------------------------------------------------------------------------------
-// ----------------------------------------------------------------------------------------
 
 void Client::rgbdImageCallback(const rgbd::RGBDMsg::ConstPtr& msg) {
 

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -110,7 +110,7 @@ bool Client::nextImage(Image& image)
 ImagePtr Client::nextImage() {
     if (shared_mem_client_.initialized())
     {
-        ImagePtr img(new Image); // TODO
+        ImagePtr img;
         if (shared_mem_client_.nextImage(*img))
             return img;
         else

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -22,7 +22,7 @@ namespace rgbd {
 
 struct ROSImageSyncData
 {
-    ROSImageSyncData() : sync_(0), sub_rgb_sync_(0), sub_depth_sync_(0) {}
+    ROSImageSyncData() : sync_(nullptr), sub_rgb_sync_(nullptr), sub_depth_sync_(nullptr) {}
 
     ~ROSImageSyncData()
     {
@@ -41,7 +41,7 @@ struct ROSImageSyncData
 
 // ----------------------------------------------------------------------------------------
 
-Client::Client() : nh_(0), ros_image_sync_data_(0)
+Client::Client() : nh_(nullptr), ros_image_sync_data_(nullptr)
 {
 }
 
@@ -117,7 +117,7 @@ ImagePtr Client::nextImage() {
             return ImagePtr();
     }
 
-    image_ptr_ = 0;
+    image_ptr_ = nullptr;
     cb_queue_.callAvailable();
     return ImagePtr(image_ptr_);
 }
@@ -170,10 +170,9 @@ void Client::imageCallback(sensor_msgs::ImageConstPtr rgb_image_msg, sensor_msgs
         return;
     }
 
-    if (!image_ptr_) {
+    if (!image_ptr_)
         // in this case, the pointer will always be wrapped in a shared ptr, so no mem leaks (see nextImage() )
         image_ptr_ = new Image();
-    }
 
     image_ptr_->rgb_image_ = img_ptr->image;
     image_ptr_->depth_image_ = depth_img_ptr->image;
@@ -200,10 +199,9 @@ void Client::rgbdImageCallback(const rgbd::RGBDMsg::ConstPtr& msg) {
         return;
     }
 
-    if (!image_ptr_) {
+    if (!image_ptr_)
         // in this case, the pointer will always be wrapped in a shared ptr, so no mem leaks (see nextImage() )
         image_ptr_ = new Image();
-    }
 
     if (msg->version == 1)
     {

--- a/src/get_3d_point_from_image_roi_node.cpp
+++ b/src/get_3d_point_from_image_roi_node.cpp
@@ -137,12 +137,12 @@ int main(int argc, char **argv)
         last_image_stamp = ros::Time(image.getTimestamp());
 
         g_last_images_.push_back(std::shared_ptr<rgbd::Image>(new rgbd::Image(image)));
-        ROS_DEBUG("Got msg...");
+        ROS_DEBUG("[get_3d_point_from_image_roi] New image added to buffer");
       }
     }
     if (!last_image_stamp.isZero() && ros::Time::now() - last_image_stamp > ros::Duration(5.0))
     {
-        ROS_ERROR("get_3d_point_from_image_roi did not receive images for 5 seconds ... restarting ...");
+        ROS_ERROR("[get_3d_point_from_image_roi] No new images received images for 5 seconds, ...restarting");
         exit(1);
     }
     r.sleep();

--- a/src/get_3d_point_from_image_roi_node.cpp
+++ b/src/get_3d_point_from_image_roi_node.cpp
@@ -113,15 +113,16 @@ bool srvGet3dPointFromROI(rgbd::Project2DTo3D::Request& req, rgbd::Project2DTo3D
 int main(int argc, char **argv)
 {
   ros::init(argc, argv, "get_3d_point_from_image_roi");
+  ros::NodeHandle nh;
 
   // Listener
   rgbd::Client client;
-  client.intialize("rgbd");
+
+  client.intialize(ros::names::resolve("rgbd"));
 
   g_last_images_.set_capacity(100);
 
   // srv
-  ros::NodeHandle nh;
   ros::ServiceServer srv_project_2d_to_3d = nh.advertiseService("project_2d_to_3d", srvGet3dPointFromROI);
   ros::Time last_image_stamp;
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -127,7 +127,7 @@ int main(int argc, char **argv) {
 
     // ------------------------------
 
-    rgbd_server.initialize("output", rgb_type, depth_type);
+    rgbd_server.initialize(ros::names::resolve("rgbd"), rgb_type, depth_type);
 
     ros::Subscriber sub_cam_info = nh.subscribe("cam_info", 1, &camInfoCallback);
 

--- a/src/shared_mem_client.cpp
+++ b/src/shared_mem_client.cpp
@@ -23,30 +23,39 @@ SharedMemClient::~SharedMemClient()
 
 // ----------------------------------------------------------------------------------------------------
 
-bool SharedMemClient::intialize(const std::string& server_name)
+bool SharedMemClient::intialize(const std::string& server_name, float timeout)
 {
-    try
+    ros::Time start = ros::Time::now();
+    ros::Time now;
+    ros::Duration d(0.1);
+    do
     {
-        std::string server_name_cp = server_name;
-        std::replace(server_name_cp.begin(), server_name_cp.end(), '/', '-');
+        try
+        {
+            std::string server_name_cp = server_name;
+            std::replace(server_name_cp.begin(), server_name_cp.end(), '/', '-');
 
-        // Open already created shared memory object.
-        shm = ipc::shared_memory_object(ipc::open_only, server_name_cp.c_str(), ipc::read_write);
+            // Open already created shared memory object.
+            shm = ipc::shared_memory_object(ipc::open_only, server_name_cp.c_str(), ipc::read_write);
 
-        mem_buffer_header = ipc::mapped_region(shm, ipc::read_write, 0, sizeof(BufferHeader));
-        mem_image = ipc::mapped_region(shm, ipc::read_only, sizeof(BufferHeader));
+            mem_buffer_header = ipc::mapped_region(shm, ipc::read_write, 0, sizeof(BufferHeader));
+            mem_image = ipc::mapped_region(shm, ipc::read_only, sizeof(BufferHeader));
 
-        buffer_header = static_cast<BufferHeader*>(mem_buffer_header.get_address());
+            buffer_header = static_cast<BufferHeader*>(mem_buffer_header.get_address());
 
-        sequence_nr = 0;
-    }
-    catch(ipc::interprocess_exception &ex)
-    {
-//        std::cout << ex.what() << std::endl;
-        return false;
-    }
+            sequence_nr = 0;
+            return true;
+        }
+        catch(ipc::interprocess_exception &ex)
+        {
+//            std::cout << ex.what() << std::endl;
+        }
+        d.sleep();
+        now = ros::Time::now();
+     }
+     while ((now - start).toSec() < timeout);
 
-    return true;
+    return false;
 }
 
 // ----------------------------------------------------------------------------------------------------

--- a/src/shared_mem_client.cpp
+++ b/src/shared_mem_client.cpp
@@ -11,7 +11,7 @@ namespace rgbd
 
 // ----------------------------------------------------------------------------------------------------
 
-SharedMemClient::SharedMemClient() : buffer_header(0)
+SharedMemClient::SharedMemClient() : buffer_header(nullptr)
 {
 }
 
@@ -53,7 +53,7 @@ bool SharedMemClient::intialize(const std::string& server_name)
 
 bool SharedMemClient::initialized()
 {
-    return (buffer_header != 0);
+    return (buffer_header != nullptr);
 }
 
 // ----------------------------------------------------------------------------------------------------

--- a/src/shared_mem_server.cpp
+++ b/src/shared_mem_server.cpp
@@ -12,7 +12,7 @@ namespace rgbd
 
 // ----------------------------------------------------------------------------------------------------
 
-SharedMemServer::SharedMemServer() : buffer_header(0)
+SharedMemServer::SharedMemServer() : buffer_header(nullptr)
 {
 }
 

--- a/src/viewer.cpp
+++ b/src/viewer.cpp
@@ -38,7 +38,7 @@ int main(int argc, char **argv)
                     for(int x = 0; x < view.getWidth(); ++x)
                     {
                         float d = view.getDepth(x, y);
-                        if (d == d)
+                        if (d == d) // ToDo: This will always be true.
                         {
                             cv::Vec3b hsv = image_hsv.at<cv::Vec3b>(y, x);
                             hsv[2] = 255 - (d / 8 * 255);

--- a/src/viewer.cpp
+++ b/src/viewer.cpp
@@ -7,7 +7,6 @@ int main(int argc, char **argv)
     ros::init(argc, argv, "rgbd_viewer");
 
     rgbd::Client client;
-//    client.intialize("rgbd");
     client.intialize("rgbd");
 
     ros::Rate r(30);

--- a/tools/multitool.cpp
+++ b/tools/multitool.cpp
@@ -88,7 +88,7 @@ int main(int argc, char **argv)
     cv::namedWindow("RGBD", 1);
 
     //set the callback function for any mouse event
-    cv::setMouseCallback("RGBD", CallBackFunc, NULL);
+    cv::setMouseCallback("RGBD", CallBackFunc, nullptr);
 
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 


### PR DESCRIPTION
The server name of the shared memory name was always `output`. This was never resolved with ROS remaps etc. This is now fixed. Also added docstrings so that it is clear that these should be resolved on higher levels.