### PR TITLE
Rwc2019

### DIFF
--- a/src/rgbd_to_ros.cpp
+++ b/src/rgbd_to_ros.cpp
@@ -21,7 +21,7 @@ int main(int argc, char **argv)
     }
 
     ros::init(argc, argv, "rgbd_to_ros");
-    ros::start();
+    ros::start(); // Required to use ros::names::resolve, without creating a nodehandle
 
     // Listener
     rgbd::Client client;

--- a/src/rgbd_to_ros.cpp
+++ b/src/rgbd_to_ros.cpp
@@ -25,7 +25,7 @@ int main(int argc, char **argv)
 
     // Listener
     rgbd::Client client;
-    client.intialize(argv[1]);
+    client.intialize(ros::names::resolve(argv[1]));
 
     // Publishers
     ros::NodeHandle nh;

--- a/src/rgbd_to_ros.cpp
+++ b/src/rgbd_to_ros.cpp
@@ -21,6 +21,7 @@ int main(int argc, char **argv)
     }
 
     ros::init(argc, argv, "rgbd_to_ros");
+    ros::start();
 
     // Listener
     rgbd::Client client;


### PR DESCRIPTION
rgbd_to_ros needed resolving to connect to the correct shared memory. To have the resolving working, ros::start is needed.