### PR TITLE
(ServerRGBD) fix service cb

### DIFF
--- a/rgbd/include/rgbd/image.h
+++ b/rgbd/include/rgbd/image.h
@@ -97,7 +97,7 @@ public:
 
     friend bool deserialize(tue::serialization::InputArchive& a, Image& image);
 
-    friend bool convert(const rgbd_msgs::RGBDConstPtr& msg, rgbd::Image* image);
+    friend bool convert(const rgbd_msgs::RGBDConstPtr& msg, rgbd::Image*& image);
 
 protected:
 

--- a/rgbd/include/rgbd/ros/conversions.h
+++ b/rgbd/include/rgbd/ros/conversions.h
@@ -46,7 +46,7 @@ bool convert(const cv::Mat& image, const geo::DepthCamera& cam_model, sensor_msg
  * @param image raw pointer to an Image. In case it is a nullptr, a new instance will be created.
  * @return success
  */
-bool convert(const rgbd_msgs::RGBDConstPtr& msg, rgbd::Image* image);
+bool convert(const rgbd_msgs::RGBDConstPtr& msg, rgbd::Image*& image);
 
 }
 

--- a/rgbd/src/ros/conversions.cpp
+++ b/rgbd/src/ros/conversions.cpp
@@ -136,7 +136,7 @@ bool convert(const cv::Mat& image,
 
 // ----------------------------------------------------------------------------------------------------
 
-bool convert(const rgbd_msgs::RGBDConstPtr& msg, rgbd::Image* image)
+bool convert(const rgbd_msgs::RGBDConstPtr& msg, rgbd::Image*& image)
 {
     if (msg->version == 0)
     {

--- a/rgbd/src/server_rgbd.cpp
+++ b/rgbd/src/server_rgbd.cpp
@@ -83,8 +83,8 @@ bool ServerRGBD::serviceCallback(rgbd_msgs::GetRGBDRequest& req, rgbd_msgs::GetR
     // Create resized images
     cv::Mat resized_rgb, resized_depth;
 
-    double ratio_rgb = static_cast<double>(req.width / image.getRGBImage().cols);
-    double ratio_depth = static_cast<double>( req.width / image.getDepthImage().cols);
+    double ratio_rgb = static_cast<double>(req.width) / static_cast<double>(image.getRGBImage().cols);
+    double ratio_depth = static_cast<double>(req.width) / static_cast<double>(image.getDepthImage().cols);
 
     cv::resize(image.getRGBImage(), resized_rgb, cv::Size(req.width, static_cast<int>(image.getRGBImage().rows * ratio_rgb)));
     cv::resize(image.getDepthImage(), resized_depth, cv::Size(req.width, static_cast<int>(image.getDepthImage().rows * ratio_depth)));


### PR DESCRIPTION
```
int/int --> int
```
So ratio was rounded to zero...

----
In case a `nullptr` is passed to `conversion` and `new` is called, outside the pointer was still a `nullptr`. Therefore a reference to a pointer needs to be passed.