### PR TITLE
compressed rgbd serialized stream

### DIFF
--- a/rgbd/CMakeLists.txt
+++ b/rgbd/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(rgbd)
 
-find_package(Boost REQUIRED)
+find_package(Boost REQUIRED COMPONENTS iostreams)
 find_package(catkin REQUIRED COMPONENTS
   cv_bridge
   geolib2


### PR DESCRIPTION
By compressing the stream, the bandwidth is reduced from 60 MB/s to 120 KB/s. I have not been able to observe a significant increase in cpu for the (de)compression.