### PR TITLE
ros_to_rgbd nodelet

### DIFF
--- a/rgbd/CMakeLists.txt
+++ b/rgbd/CMakeLists.txt
@@ -8,7 +8,9 @@ find_package(catkin REQUIRED COMPONENTS
   geometry_msgs
   image_geometry
   message_filters
+  nodelet
   pcl_ros
+  pluginlib
   rgbd_msgs
   roscpp
   sensor_msgs
@@ -54,6 +56,11 @@ add_library(rgbd    src/client.cpp
                     ${HEADER_FILES})
 target_link_libraries(rgbd ${catkin_LIBRARIES} rt)
 add_dependencies(rgbd ${catkin_EXPORTED_TARGETS})
+
+# - - - - - - - - - - - - - - - - NODELETS - - - - - - - - - - - - - - - -
+
+#add_library(rgbd_nodelets src/nodelets/ros_to_rgbd.cpp)
+#target_link_libraries(rgbd_nodelets rgbd ${catkin_LIBRARIES})
 
 # - - - - - - - - - - - - - - - - - NODES - - - - - - - - - - - - - - - - -
 

--- a/rgbd/CMakeLists.txt
+++ b/rgbd/CMakeLists.txt
@@ -42,6 +42,7 @@ file(GLOB_RECURSE HEADER_FILES include/*.h)
 
 add_library(rgbd    src/client.cpp
                     src/client_rgbd.cpp
+                    src/client_ros_base.cpp
                     src/client_ros.cpp
                     src/client_shm.cpp
                     src/serialization.cpp
@@ -59,8 +60,8 @@ add_dependencies(rgbd ${catkin_EXPORTED_TARGETS})
 
 # - - - - - - - - - - - - - - - - NODELETS - - - - - - - - - - - - - - - -
 
-#add_library(rgbd_nodelets src/nodelets/ros_to_rgbd.cpp)
-#target_link_libraries(rgbd_nodelets rgbd ${catkin_LIBRARIES})
+add_library(rgbd_nodelets src/nodelets/ros_to_rgbd.cpp)
+target_link_libraries(rgbd_nodelets rgbd ${catkin_LIBRARIES})
 
 # - - - - - - - - - - - - - - - - - NODES - - - - - - - - - - - - - - - - -
 

--- a/rgbd/include/rgbd/client_ros.h
+++ b/rgbd/include/rgbd/client_ros.h
@@ -7,6 +7,7 @@
 
 #include <ros/node_handle.h>
 #include <ros/callback_queue.h>
+#include "ros/callback_queue_interface.h"
 
 #include <message_filters/synchronizer.h>
 #include <message_filters/subscriber.h>
@@ -16,6 +17,7 @@
 #include <sensor_msgs/Image.h>
 #include <sensor_msgs/CameraInfo.h>
 
+#include "rgbd/client_ros_base.h"
 #include "rgbd/types.h"
 
 #include <memory>
@@ -23,26 +25,20 @@
 
 namespace rgbd {
 
-typedef message_filters::sync_policies::ApproximateTime<sensor_msgs::Image, sensor_msgs::Image> RGBDApproxPolicy;
-
 /**
  * @brief Client which subscribes to regular ROS image topics
  */
-class ClientROS {
+class ClientROS : public ClientROSBase {
 
 public:
 
     /**
      * @brief Constructor
-     *
-     * Pointers are initialized to nullptr
      */
-    ClientROS(ros::NodeHandlePtr nh=nullptr, ros::CallbackQueuePtr cb_queue=nullptr);
+    ClientROS();
 
     /**
      * @brief Destructor
-     *
-     * image_ptr_ is not delete as the client never owns the image pointer
      */
     virtual ~ClientROS();
 
@@ -54,12 +50,6 @@ public:
      * @return indicates success
      */
     bool initialize(const std::string& rgb_image_topic, const std::string& depth_image_topic, const std::string& cam_info_topic);
-
-    /**
-     * @brief Check if the client is initialized. nextImage will not return an image if client is not initialized.
-     * @return initialized or not
-     */
-    bool initialized() { return sync_.operator bool(); }
 
     /**
      * @brief Get a new Image. If no new image has been received since the last call,
@@ -78,37 +68,7 @@ public:
 
 protected:
 
-    ros::NodeHandlePtr nh_;
-    ros::CallbackQueuePtr cb_queue_;
-
-    std::unique_ptr<message_filters::Synchronizer<RGBDApproxPolicy> > sync_;
-    std::unique_ptr<message_filters::Subscriber<sensor_msgs::Image> > sub_rgb_sync_;
-    std::unique_ptr<message_filters::Subscriber<sensor_msgs::Image> > sub_depth_sync_;
-    ros::Subscriber sub_cam_info_;
-    image_geometry::PinholeCameraModel cam_model_;
-
-    /**
-     * @brief new_image_ Track if image is updated in a callback.
-     */
-    bool new_image_;
-    /**
-     * @brief image_ptr_ Pointer to image. Image could be provided by reference or the pointer will be wrapped in a shared_ptr.
-     * Either this class will never take ownership.
-     */
-    Image* image_ptr_;
-
-    /**
-     * @brief Callback for CameraInfo, will unsubscribe after succesfully receiving first message.
-     * @param cam_info_msg message
-     */
-    void camInfoCallback(const sensor_msgs::CameraInfoConstPtr& cam_info_msg);
-
-    /**
-     * @brief Callback for synched rgb and depth image
-     * @param rgb_image_msg rgb image message
-     * @param depth_image_msg depth image message
-     */
-    void imageCallback(const sensor_msgs::ImageConstPtr& rgb_image_msg, const sensor_msgs::ImageConstPtr& depth_image_msg);
+    ros::CallbackQueue cb_queue_;
 
 };
 

--- a/rgbd/include/rgbd/client_ros.h
+++ b/rgbd/include/rgbd/client_ros.h
@@ -37,7 +37,7 @@ public:
      *
      * Pointers are initialized to nullptr
      */
-    ClientROS();
+    ClientROS(ros::NodeHandlePtr nh=nullptr, ros::CallbackQueuePtr cb_queue=nullptr);
 
     /**
      * @brief Destructor
@@ -78,8 +78,8 @@ public:
 
 protected:
 
-    ros::NodeHandle nh_;
-    ros::CallbackQueue cb_queue_;
+    ros::NodeHandlePtr nh_;
+    ros::CallbackQueuePtr cb_queue_;
 
     std::unique_ptr<message_filters::Synchronizer<RGBDApproxPolicy> > sync_;
     std::unique_ptr<message_filters::Subscriber<sensor_msgs::Image> > sub_rgb_sync_;

--- a/rgbd/include/rgbd/client_ros_base.h
+++ b/rgbd/include/rgbd/client_ros_base.h
@@ -1,0 +1,103 @@
+/**
+ * This client converts rgb/depth/camera_info into RGBD::Image
+ */
+
+#ifndef RGBD_CLIENT_ROS_BASE_H_
+#define RGBD_CLIENT_ROS_BASE_H_
+
+#include <ros/node_handle.h>
+#include <ros/callback_queue.h>
+#include "ros/callback_queue_interface.h"
+
+#include <message_filters/synchronizer.h>
+#include <message_filters/subscriber.h>
+#include <message_filters/sync_policies/approximate_time.h>
+#include <image_geometry/pinhole_camera_model.h>
+
+#include <sensor_msgs/Image.h>
+#include <sensor_msgs/CameraInfo.h>
+
+#include "rgbd/types.h"
+
+#include <memory>
+
+
+namespace rgbd {
+
+typedef message_filters::sync_policies::ApproximateTime<sensor_msgs::Image, sensor_msgs::Image> RGBDApproxPolicy;
+
+/**
+ * @brief Client which subscribes to regular ROS image topics
+ */
+class ClientROSBase {
+
+public:
+
+    /**
+     * @brief Constructor
+     *
+     * Pointers are initialized to nullptr
+     */
+    ClientROSBase(ros::NodeHandle nh);
+
+    /**
+     * @brief Destructor
+     *
+     * image_ptr_ is not delete as the client never owns the image pointer
+     */
+    virtual ~ClientROSBase();
+
+    /**
+     * @brief Initialize the subscriber
+     * @param rgb_image_topic topic name of the rgb image; topic will still be resolved.
+     * @param depth_image_topic topic name of the depth image; topic will still be resolved.
+     * @param cam_info_topic topic name of the camera info; topic will still be resolved.
+     * @return indicates success
+     */
+    bool initialize(const std::string& rgb_image_topic, const std::string& depth_image_topic, const std::string& cam_info_topic);
+
+    /**
+     * @brief Check if the client is initialized. nextImage will not return an image if client is not initialized.
+     * @return initialized or not
+     */
+    bool initialized() { return bool(sync_); }
+
+protected:
+
+    ros::NodeHandle nh_;
+
+    std::unique_ptr<message_filters::Synchronizer<RGBDApproxPolicy> > sync_;
+    std::unique_ptr<message_filters::Subscriber<sensor_msgs::Image> > sub_rgb_sync_;
+    std::unique_ptr<message_filters::Subscriber<sensor_msgs::Image> > sub_depth_sync_;
+    ros::Subscriber sub_cam_info_;
+    image_geometry::PinholeCameraModel cam_model_;
+
+    /**
+     * @brief new_image_ Track if image is updated in a callback.
+     */
+    bool new_image_;
+    /**
+     * @brief image_ptr_ Pointer to image. Image could be provided by reference or the pointer will be wrapped in a shared_ptr.
+     * Either this class will never take ownership.
+     */
+    Image* image_ptr_;
+
+    /**
+     * @brief Callback for CameraInfo, will unsubscribe after succesfully receiving first message.
+     * @param cam_info_msg message
+     */
+    void camInfoCallback(const sensor_msgs::CameraInfoConstPtr& cam_info_msg);
+
+    /**
+     * @brief Callback for synched rgb and depth image
+     * @param rgb_image_msg rgb image message
+     * @param depth_image_msg depth image message
+     * @return success
+     */
+    bool imageCallback(const sensor_msgs::ImageConstPtr& rgb_image_msg, const sensor_msgs::ImageConstPtr& depth_image_msg);
+
+};
+
+}
+
+#endif // RGBD_CLIENT_ROS_BASE_H_

--- a/rgbd/include/rgbd/server.h
+++ b/rgbd/include/rgbd/server.h
@@ -25,7 +25,7 @@ public:
     /**
      * @brief Constructor
      */
-    Server(ros::NodeHandlePtr nh=nullptr);
+    Server(ros::NodeHandle nh=ros::NodeHandle());
 
     /**
      * @brief Destructor
@@ -54,7 +54,7 @@ protected:
 
     ServerSHM server_shm_;
 
-    ros::NodeHandlePtr nh_;
+    ros::NodeHandle nh_;
 
     std::string name_;
     std::string hostname_;

--- a/rgbd/include/rgbd/server.h
+++ b/rgbd/include/rgbd/server.h
@@ -25,7 +25,7 @@ public:
     /**
      * @brief Constructor
      */
-    Server();
+    Server(ros::NodeHandlePtr nh=nullptr);
 
     /**
      * @brief Destructor
@@ -54,7 +54,7 @@ protected:
 
     ServerSHM server_shm_;
 
-    ros::NodeHandle nh_;
+    ros::NodeHandlePtr nh_;
 
     std::string name_;
     std::string hostname_;

--- a/rgbd/include/rgbd/server_rgbd.h
+++ b/rgbd/include/rgbd/server_rgbd.h
@@ -24,7 +24,7 @@ public:
     /**
      * @brief Constructor
      */
-    ServerRGBD(ros::NodeHandlePtr nh=nullptr);
+    ServerRGBD(ros::NodeHandle nh=ros::NodeHandle());
 
     /**
      * @brief Destructor
@@ -55,7 +55,7 @@ public:
 
 protected:
 
-    ros::NodeHandlePtr nh_;
+    ros::NodeHandle nh_;
     ros::Publisher pub_image_;
     ros::ServiceServer service_server_;
     ros::CallbackQueue cb_queue_;

--- a/rgbd/include/rgbd/server_rgbd.h
+++ b/rgbd/include/rgbd/server_rgbd.h
@@ -24,7 +24,7 @@ public:
     /**
      * @brief Constructor
      */
-    ServerRGBD();
+    ServerRGBD(ros::NodeHandlePtr nh=nullptr);
 
     /**
      * @brief Destructor
@@ -55,7 +55,7 @@ public:
 
 protected:
 
-    ros::NodeHandle nh_;
+    ros::NodeHandlePtr nh_;
     ros::Publisher pub_image_;
     ros::ServiceServer service_server_;
     ros::CallbackQueue cb_queue_;

--- a/rgbd/include/rgbd/server_shm.h
+++ b/rgbd/include/rgbd/server_shm.h
@@ -4,12 +4,11 @@
 #include <boost/interprocess/shared_memory_object.hpp>
 #include <boost/interprocess/mapped_region.hpp>
 
+#include <ros/node_handle.h>
+
 #include "rgbd/image_header.h"
 #include "rgbd/types.h"
 
-namespace ros {
-class NodeHandle;
-}
 
 namespace rgbd
 {

--- a/rgbd/nodelet_plugins.xml
+++ b/rgbd/nodelet_plugins.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<library path="lib/librgbd_nodelets">
+
+  <class name="rgbd/ros_to_rgbd" type="rgbd::ROSToRGBDNodelet" base_class_type="nodelet::Nodelet">
+    <description>
+      Nodelet converting from ros rgb and depth image to combined RGBD message.
+    </description>
+  </class>
+
+</library>

--- a/rgbd/package.xml
+++ b/rgbd/package.xml
@@ -22,7 +22,9 @@
   <depend>geometry_msgs</depend>
   <depend>image_geometry</depend>
   <depend>message_filters</depend>
+  <depend>nodelet</depend>
   <depend>pcl_ros</depend>
+  <depend>pluginlib</depend>
   <depend>rgbd_msgs</depend>
   <depend>roscpp</depend>
   <depend>sensor_msgs</depend>

--- a/rgbd/package.xml
+++ b/rgbd/package.xml
@@ -33,6 +33,7 @@
   <doc_depend>doxygen</doc_depend>
 
   <export>
+    <nodelet plugin="${prefix}/nodelet_plugins.xml" />
     <rosdoc config="rosdoc.yaml" />
   </export>
 

--- a/rgbd/src/client_ros.cpp
+++ b/rgbd/src/client_ros.cpp
@@ -14,41 +14,25 @@ namespace rgbd {
 
 // ----------------------------------------------------------------------------------------
 
-ClientROS::ClientROS(ros::NodeHandlePtr nh, ros::CallbackQueuePtr cb_queue) : nh_(nullptr), cb_queue_(nullptr), sync_(nullptr), sub_rgb_sync_(nullptr), sub_depth_sync_(nullptr), image_ptr_(nullptr)
+ClientROS::ClientROS() : ClientROSBase(ros::NodeHandle())
 {
-    if (nh)
-        nh_ = nh;
-    else
-        nh_ = boost::make_shared<ros::NodeHandle>();
-
-    if (cb_queue)
-        cb_queue_ = cb_queue;
-    else
-        cb_queue_ = boost::make_shared<ros::CallbackQueue>();
 }
 
 // ----------------------------------------------------------------------------------------
 
 ClientROS::~ClientROS()
 {
-    nh_->shutdown();
-    sync_.reset();
-    sub_rgb_sync_.reset();
-    sub_depth_sync_.reset();
 }
 
 // ----------------------------------------------------------------------------------------
 
 bool ClientROS::initialize(const std::string& rgb_image_topic, const std::string& depth_image_topic, const std::string& cam_info_topic)
 {
-    nh_->setCallbackQueue(cb_queue_.get());
+    nh_.setCallbackQueue(&cb_queue_);
 
-    sub_cam_info_ = nh_->subscribe(cam_info_topic, 1, &ClientROS::camInfoCallback, this);
+    if (!ClientROSBase::initialize(rgb_image_topic, depth_image_topic, cam_info_topic))
+        return false;
 
-    sub_rgb_sync_ = std::make_unique<message_filters::Subscriber<sensor_msgs::Image> >(nh_, rgb_image_topic, 1);
-    sub_depth_sync_ = std::make_unique<message_filters::Subscriber<sensor_msgs::Image> >(nh_, depth_image_topic, 1);
-
-    sync_ = std::unique_ptr<message_filters::Synchronizer<RGBDApproxPolicy> >(new message_filters::Synchronizer<RGBDApproxPolicy>(RGBDApproxPolicy(10), *sub_rgb_sync_, *sub_depth_sync_));
     sync_->registerCallback(boost::bind(&ClientROS::imageCallback, this, _1, _2));
 
     return true;
@@ -60,7 +44,7 @@ bool ClientROS::nextImage(Image& image)
 {
     new_image_ = false;
     image_ptr_ = &image;
-    cb_queue_->callAvailable();
+    cb_queue_.callAvailable();
     return new_image_;
 }
 
@@ -69,85 +53,8 @@ bool ClientROS::nextImage(Image& image)
 ImagePtr ClientROS::nextImage()
 {
     image_ptr_ = nullptr;
-    cb_queue_->callAvailable();
+    cb_queue_.callAvailable();
     return ImagePtr(image_ptr_);
-}
-
-// ----------------------------------------------------------------------------------------
-
-void ClientROS::camInfoCallback(const sensor_msgs::CameraInfoConstPtr& cam_info_msg)
-{
-    if (!cam_model_.initialized())
-    {
-        cam_model_.fromCameraInfo(cam_info_msg);
-        sub_cam_info_.shutdown();
-    }
-    else
-    {
-        ROS_ERROR("CameraInfo should unsubsribe after inititializing the camera model");
-    }
-}
-
-// ----------------------------------------------------------------------------------------
-
-void ClientROS::imageCallback(const sensor_msgs::ImageConstPtr& rgb_image_msg, const sensor_msgs::ImageConstPtr& depth_image_msg)
-{
-    if (!cam_model_.initialized())
-    {
-        ROS_ERROR("ClientROS: cam_model not yet initialized");
-        return;
-    }
-    cv_bridge::CvImagePtr rgb_img_ptr, depth_img_ptr;
-
-    // Convert RGB image
-    try
-    {
-        rgb_img_ptr = cv_bridge::toCvCopy(rgb_image_msg, sensor_msgs::image_encodings::BGR8);
-    }
-    catch (cv_bridge::Exception& e)
-    {
-        ROS_ERROR("ClientROS: Could not deserialize rgb image: %s", e.what());
-        return;
-    }
-
-    // Convert depth image
-    try
-    {
-        // cv_bridge doesn't support changing the encoding of depth images, so just creating ImagePtr
-        depth_img_ptr = cv_bridge::toCvCopy(depth_image_msg, depth_image_msg->encoding);
-
-        if (depth_image_msg->encoding == sensor_msgs::image_encodings::TYPE_16UC1)
-        {
-            // depths are 16-bit unsigned ints, in mm. Convert to 32-bit float (meters)
-            cv::Mat depth_image(depth_img_ptr->image.rows, depth_img_ptr->image.cols, CV_32FC1);
-            for(int x = 0; x < depth_image.cols; ++x)
-            {
-                for(int y = 0; y < depth_image.rows; ++y)
-                {
-                    depth_image.at<float>(y, x) = static_cast<float>(depth_img_ptr->image.at<unsigned short>(y, x)) / 1000; // (mm to m)
-                }
-            }
-
-            depth_img_ptr->image = depth_image;
-        }
-
-    }
-    catch (cv_bridge::Exception& e)
-    {
-        ROS_ERROR("ClientROS: Could not deserialize depth image: %s", e.what());
-        return;
-    }
-
-    if (!image_ptr_)
-        // in this case, the pointer will always be wrapped in a shared ptr, so no mem leaks (see nextImage() )
-        image_ptr_ = new Image();
-
-    image_ptr_->setRGBImage(rgb_img_ptr->image);
-    image_ptr_->setDepthImage(depth_img_ptr->image);
-    image_ptr_->setCameraModel(cam_model_);
-    image_ptr_->setFrameId(rgb_image_msg->header.frame_id);
-    image_ptr_->setTimestamp(rgb_image_msg->header.stamp.toSec());
-    new_image_ = true;
 }
 
 }

--- a/rgbd/src/client_ros_base.cpp
+++ b/rgbd/src/client_ros_base.cpp
@@ -1,0 +1,124 @@
+#include "rgbd/client_ros.h"
+#include "rgbd/image.h"
+
+// ROS message serialization
+#include <cv_bridge/cv_bridge.h>
+#include <message_filters/synchronizer.h>
+#include <message_filters/subscriber.h>
+#include <message_filters/sync_policies/approximate_time.h>
+#include <sensor_msgs/Image.h>
+#include <sensor_msgs/image_encodings.h>
+#include <image_geometry/pinhole_camera_model.h>
+
+namespace rgbd {
+
+// ----------------------------------------------------------------------------------------
+
+ClientROSBase::ClientROSBase(ros::NodeHandle nh) : nh_(nh), sync_(nullptr), sub_rgb_sync_(nullptr), sub_depth_sync_(nullptr), image_ptr_(nullptr)
+{
+}
+
+// ----------------------------------------------------------------------------------------
+
+ClientROSBase::~ClientROSBase()
+{
+    nh_.shutdown();
+    sync_.reset();
+    sub_rgb_sync_.reset();
+    sub_depth_sync_.reset();
+}
+
+// ----------------------------------------------------------------------------------------
+
+bool ClientROSBase::initialize(const std::string& rgb_image_topic, const std::string& depth_image_topic, const std::string& cam_info_topic)
+{
+    sub_cam_info_ = nh_.subscribe(cam_info_topic, 1, &ClientROSBase::camInfoCallback, this);
+
+    sub_rgb_sync_ = std::unique_ptr<message_filters::Subscriber<sensor_msgs::Image> >(new message_filters::Subscriber<sensor_msgs::Image>(nh_, rgb_image_topic, 1));
+    sub_depth_sync_ = std::unique_ptr<message_filters::Subscriber<sensor_msgs::Image> >(new message_filters::Subscriber<sensor_msgs::Image>(nh_, depth_image_topic, 1));
+
+    sync_ = std::unique_ptr<message_filters::Synchronizer<RGBDApproxPolicy> >(new message_filters::Synchronizer<RGBDApproxPolicy>(RGBDApproxPolicy(10), *sub_rgb_sync_, *sub_depth_sync_));
+
+    return true;
+}
+
+// ----------------------------------------------------------------------------------------
+
+void ClientROSBase::camInfoCallback(const sensor_msgs::CameraInfoConstPtr& cam_info_msg)
+{
+    if (!cam_model_.initialized())
+    {
+        cam_model_.fromCameraInfo(cam_info_msg);
+        sub_cam_info_.shutdown();
+    }
+    else
+    {
+        ROS_ERROR("CameraInfo should unsubsribe after inititializing the camera model");
+    }
+}
+
+// ----------------------------------------------------------------------------------------
+
+bool ClientROSBase::imageCallback(const sensor_msgs::ImageConstPtr& rgb_image_msg, const sensor_msgs::ImageConstPtr& depth_image_msg)
+{
+    if (!cam_model_.initialized())
+    {
+        ROS_ERROR("ClientROSBase: cam_model not yet initialized");
+        return false;
+    }
+    cv_bridge::CvImagePtr rgb_img_ptr, depth_img_ptr;
+
+    // Convert RGB image
+    try
+    {
+        rgb_img_ptr = cv_bridge::toCvCopy(rgb_image_msg, sensor_msgs::image_encodings::BGR8);
+    }
+    catch (cv_bridge::Exception& e)
+    {
+        ROS_ERROR("ClientROSBase: Could not deserialize rgb image: %s", e.what());
+        return false;
+    }
+
+    // Convert depth image
+    try
+    {
+        // cv_bridge doesn't support changing the encoding of depth images, so just creating ImagePtr
+        depth_img_ptr = cv_bridge::toCvCopy(depth_image_msg, depth_image_msg->encoding);
+
+        if (depth_image_msg->encoding == sensor_msgs::image_encodings::TYPE_16UC1)
+        {
+            // depths are 16-bit unsigned ints, in mm. Convert to 32-bit float (meters)
+            cv::Mat depth_image(depth_img_ptr->image.rows, depth_img_ptr->image.cols, CV_32FC1);
+            for(int x = 0; x < depth_image.cols; ++x)
+            {
+                for(int y = 0; y < depth_image.rows; ++y)
+                {
+                    depth_image.at<float>(y, x) = static_cast<float>(depth_img_ptr->image.at<unsigned short>(y, x)) / 1000; // (mm to m)
+                }
+            }
+
+            depth_img_ptr->image = depth_image;
+        }
+
+    }
+    catch (cv_bridge::Exception& e)
+    {
+        ROS_ERROR("ClientROSBase: Could not deserialize depth image: %s", e.what());
+        return false;
+    }
+
+    if (!image_ptr_)
+        // in this case, the pointer will always be wrapped in a shared ptr, so no mem leaks (see nextImage() )
+        image_ptr_ = new Image();
+
+    image_ptr_->setRGBImage(rgb_img_ptr->image);
+    image_ptr_->setDepthImage(depth_img_ptr->image);
+    image_ptr_->setCameraModel(cam_model_);
+    image_ptr_->setFrameId(rgb_image_msg->header.frame_id);
+    image_ptr_->setTimestamp(rgb_image_msg->header.stamp.toSec());
+    new_image_ = true;
+
+    return true;
+}
+
+}

--- a/rgbd/src/nodelets/ros_to_rgbd.cpp
+++ b/rgbd/src/nodelets/ros_to_rgbd.cpp
@@ -1,0 +1,39 @@
+#include <pluginlib/class_list_macros.hpp>
+#include <nodelet/nodelet.h>
+#include <ros/ros.h>
+
+
+namespace rgbd
+{
+
+class Plus : public nodelet::Nodelet
+{
+public:
+  Plus()
+  : value_(0)
+  {}
+
+private:
+  virtual void onInit()
+  {
+    ros::NodeHandle& private_nh = getPrivateNodeHandle();
+    private_nh.getParam("value", value_);
+    pub = private_nh.advertise<std_msgs::Float64>("out", 10);
+    sub = private_nh.subscribe("in", 10, &Plus::callback, this);
+  }
+
+  void callback(const std_msgs::Float64::ConstPtr& input)
+  {
+    std_msgs::Float64Ptr output(new std_msgs::Float64());
+    output->data = input->data + value_;
+    NODELET_DEBUG("Adding %f to get %f", value_, output->data);
+    pub.publish(output);
+  }
+
+  ros::Publisher pub;
+  ros::Subscriber sub;
+  double value_;
+};
+
+PLUGINLIB_EXPORT_CLASS(test_nodelet::Plus, nodelet::Nodelet)
+}

--- a/rgbd/src/nodelets/ros_to_rgbd.cpp
+++ b/rgbd/src/nodelets/ros_to_rgbd.cpp
@@ -1,39 +1,118 @@
-#include <pluginlib/class_list_macros.hpp>
 #include <nodelet/nodelet.h>
-#include <ros/ros.h>
+#include <nodelet/detail/callback_queue.h>
+
+#include <pluginlib/class_list_macros.hpp>
+
+#include <ros/node_handle.h>
+#include <ros/console.h>
+
+#include "rgbd/client_ros_base.h"
+#include "rgbd/image.h"
+#include "rgbd/server.h"
+
+#include <memory>
 
 
 namespace rgbd
 {
 
-class Plus : public nodelet::Nodelet
+class ClientRosNodelet : public ClientROSBase
 {
 public:
-  Plus()
-  : value_(0)
-  {}
+    ClientRosNodelet(ros::NodeHandle& nh) : ClientROSBase(nh)
+    {
+    }
 
-private:
-  virtual void onInit()
-  {
-    ros::NodeHandle& private_nh = getPrivateNodeHandle();
-    private_nh.getParam("value", value_);
-    pub = private_nh.advertise<std_msgs::Float64>("out", 10);
-    sub = private_nh.subscribe("in", 10, &Plus::callback, this);
-  }
+    ~ClientRosNodelet()
+    {
+    }
 
-  void callback(const std_msgs::Float64::ConstPtr& input)
-  {
-    std_msgs::Float64Ptr output(new std_msgs::Float64());
-    output->data = input->data + value_;
-    NODELET_DEBUG("Adding %f to get %f", value_, output->data);
-    pub.publish(output);
-  }
+    const Image* getImage()
+    {
+        return image_ptr_;
+    }
 
-  ros::Publisher pub;
-  ros::Subscriber sub;
-  double value_;
+    message_filters::Synchronizer<RGBDApproxPolicy>* getSync()
+    {
+        return sync_.get();
+    }
+
+    using ClientROSBase::imageCallback;
+
 };
 
-PLUGINLIB_EXPORT_CLASS(test_nodelet::Plus, nodelet::Nodelet)
-}
+class ROSToRGBDNodelet : public nodelet::Nodelet
+{
+public:
+    ROSToRGBDNodelet()
+    {
+    }
+
+private:
+    virtual void onInit()
+    {
+        ros::NodeHandle nh = getNodeHandle();
+        ros::NodeHandle nh_private = getPrivateNodeHandle();
+
+        // ----- READ RGB STORAGE TYPE
+
+        rgbd::RGBStorageType rgb_type;
+
+        std::string rgb_type_str = "lossless";
+        nh_private.getParam("rgb_storage", rgb_type_str);
+        if (rgb_type_str == "none")
+            rgb_type = rgbd::RGB_STORAGE_NONE;
+        else if (rgb_type_str == "lossless")
+            rgb_type = rgbd::RGB_STORAGE_LOSSLESS;
+        else if (rgb_type_str == "jpg")
+            rgb_type = rgbd::RGB_STORAGE_JPG;
+        else
+        {
+            ROS_ERROR("Unknown 'rgb_storage' type: should be 'none', 'lossless', or 'jpg'.");
+            return;
+        }
+
+        // ----- READ DEPTH STORAGE TYPE
+
+        rgbd::DepthStorageType depth_type;
+
+        std::string depth_type_str = "lossless";
+        nh_private.getParam("depth_storage", depth_type_str);
+        if (depth_type_str == "none")
+            depth_type = rgbd::DEPTH_STORAGE_NONE;
+        else if (depth_type_str == "lossless")
+            depth_type = rgbd::DEPTH_STORAGE_LOSSLESS;
+        else if (depth_type_str == "png")
+            depth_type = rgbd::DEPTH_STORAGE_PNG;
+        else
+        {
+            ROS_ERROR("Unknown 'depth_storage' type: should be 'none', 'lossless', or 'png'.");
+            return;
+        }
+
+        client_ = std::make_unique<rgbd::ClientRosNodelet>(nh);
+        client_->initialize("rgb_image", "depth_image", "cam_info");
+
+        server_ = std::make_unique<rgbd::Server>(nh);
+        server_->initialize(ros::names::resolve("rgbd"), rgb_type, depth_type);
+
+        client_->getSync()->registerCallback(boost::bind(&ROSToRGBDNodelet::imageCallback, this, _1, _2));
+    }
+
+    void imageCallback(const sensor_msgs::ImageConstPtr& rgb_image_msg, const sensor_msgs::ImageConstPtr& depth_image_msg)
+    {
+        if (!client_->imageCallback(rgb_image_msg, depth_image_msg))
+        {
+            ROS_ERROR("Error during processing the image callback. See log above.");
+            return;
+        }
+        server_->send(*client_->getImage());
+    }
+
+    std::unique_ptr<rgbd::ClientRosNodelet> client_;
+    std::unique_ptr<rgbd::Server> server_;
+};
+
+PLUGINLIB_EXPORT_CLASS(rgbd::ROSToRGBDNodelet, nodelet::Nodelet)
+
+} // end namespace rgbd

--- a/rgbd/src/rgbd_to_shm.cpp
+++ b/rgbd/src/rgbd_to_shm.cpp
@@ -42,7 +42,7 @@ int main(int argc, char **argv)
     client.initialize(server_name);
     server.initialize(server_name);
 
-    ros::NodeHandle nh;
+    ros::NodeHandlePtr nh = boost::make_shared<ros::NodeHandle>();
     std::unique_ptr<std::thread> pub_hostname_thread_ptr(nullptr);
 
     rgbd::ImagePtr image_ptr;
@@ -65,13 +65,13 @@ int main(int argc, char **argv)
         if (image_ptr)
         {
             if (!pub_hostname_thread_ptr)
-                pub_hostname_thread_ptr = std::unique_ptr<std::thread>(new std::thread(rgbd::pubHostnameThreadFunc, std::ref(nh), server_name, host_name, 10));
+                pub_hostname_thread_ptr = std::make_unique<std::thread>(rgbd::pubHostnameThreadFunc, std::ref(nh), server_name, host_name, 10);
             server.send(*image_ptr);
         }
         r.sleep();
     }
 
-    nh.shutdown();
+    nh->shutdown();
     if(pub_hostname_thread_ptr)
         pub_hostname_thread_ptr->join();
 

--- a/rgbd/src/rgbd_to_shm.cpp
+++ b/rgbd/src/rgbd_to_shm.cpp
@@ -42,7 +42,7 @@ int main(int argc, char **argv)
     client.initialize(server_name);
     server.initialize(server_name);
 
-    ros::NodeHandle nh = ros::NodeHandle();
+    ros::NodeHandle nh;
     std::unique_ptr<std::thread> pub_hostname_thread_ptr(nullptr);
 
     rgbd::ImagePtr image_ptr;

--- a/rgbd/src/rgbd_to_shm.cpp
+++ b/rgbd/src/rgbd_to_shm.cpp
@@ -42,7 +42,7 @@ int main(int argc, char **argv)
     client.initialize(server_name);
     server.initialize(server_name);
 
-    ros::NodeHandlePtr nh = boost::make_shared<ros::NodeHandle>();
+    ros::NodeHandle nh = ros::NodeHandle();
     std::unique_ptr<std::thread> pub_hostname_thread_ptr(nullptr);
 
     rgbd::ImagePtr image_ptr;
@@ -71,7 +71,7 @@ int main(int argc, char **argv)
         r.sleep();
     }
 
-    nh->shutdown();
+    nh.shutdown();
     if(pub_hostname_thread_ptr)
         pub_hostname_thread_ptr->join();
 

--- a/rgbd/src/server.cpp
+++ b/rgbd/src/server.cpp
@@ -9,12 +9,8 @@ namespace rgbd {
 
 // ----------------------------------------------------------------------------------------
 
-Server::Server(ros::NodeHandlePtr nh) : nh_(nullptr), pub_hostname_thread_ptr_(nullptr)
+Server::Server(ros::NodeHandle nh) : nh_(nh), pub_hostname_thread_ptr_(nullptr)
 {
-    if (nh)
-        nh_ = nh;
-    else
-        nh_ = boost::make_shared<ros::NodeHandle>();
     const std::string& hostname = get_hostname();
     hostname_ = hostname;
 }
@@ -23,7 +19,7 @@ Server::Server(ros::NodeHandlePtr nh) : nh_(nullptr), pub_hostname_thread_ptr_(n
 
 Server::~Server()
 {
-    nh_->shutdown();
+    nh_.shutdown();
     if (pub_hostname_thread_ptr_)
         pub_hostname_thread_ptr_->join();
 }

--- a/rgbd/src/server_rgbd.cpp
+++ b/rgbd/src/server_rgbd.cpp
@@ -62,7 +62,7 @@ void ServerRGBD::send(const Image& image)
     if (pub_image_.getNumSubscribers() == 0)
         return;
 
-    rgbd_msgs::RGBDPtr msg = std::make_shared<rgbd_msgs::RGBD>();
+    rgbd_msgs::RGBDPtr msg = boost::make_shared<rgbd_msgs::RGBD>();
     msg->version = MESSAGE_VERSION;
 
     std::stringstream stream, stream2;

--- a/rgbd/src/server_rgbd.cpp
+++ b/rgbd/src/server_rgbd.cpp
@@ -62,7 +62,7 @@ void ServerRGBD::send(const Image& image)
     if (pub_image_.getNumSubscribers() == 0)
         return;
 
-    rgbd_msgs::RGBDPtr msg(new rgbd_msgs::RGBD);
+    rgbd_msgs::RGBDPtr msg = std::make_shared<rgbd_msgs::RGBD>();
     msg->version = MESSAGE_VERSION;
 
     std::stringstream stream, stream2;

--- a/rgbd/src/server_rgbd.cpp
+++ b/rgbd/src/server_rgbd.cpp
@@ -25,19 +25,15 @@ const int ServerRGBD::MESSAGE_VERSION = 3;
 
 // ----------------------------------------------------------------------------------------
 
-ServerRGBD::ServerRGBD(ros::NodeHandlePtr nh) : nh_(nullptr)
+ServerRGBD::ServerRGBD(ros::NodeHandle nh) : nh_(nh)
 {
-    if (nh)
-        nh_ = nh;
-    else
-        nh_ = boost::make_shared<ros::NodeHandle>();
 }
 
 // ----------------------------------------------------------------------------------------
 
 ServerRGBD::~ServerRGBD()
 {
-    nh_->shutdown();
+    nh_.shutdown();
     service_thread_.join();
 }
 
@@ -45,12 +41,12 @@ ServerRGBD::~ServerRGBD()
 
 void ServerRGBD::initialize(const std::string& name, RGBStorageType rgb_type, DepthStorageType depth_type, const float service_freq)
 {
-    pub_image_ = nh_->advertise<rgbd_msgs::RGBD>(name, 1);
+    pub_image_ = nh_.advertise<rgbd_msgs::RGBD>(name, 1);
     rgb_type_ = rgb_type;
     depth_type_ = depth_type;
 
-    nh_->setCallbackQueue(&cb_queue_);
-    service_server_ = nh_->advertiseService(name, &ServerRGBD::serviceCallback, this);
+    nh_.setCallbackQueue(&cb_queue_);
+    service_server_ = nh_.advertiseService(name, &ServerRGBD::serviceCallback, this);
     service_thread_ = std::thread(&ServerRGBD::serviceThreadFunc, this, service_freq);
 }
 
@@ -121,7 +117,7 @@ bool ServerRGBD::serviceCallback(rgbd_msgs::GetRGBDRequest& req, rgbd_msgs::GetR
 void ServerRGBD::serviceThreadFunc(const float freq)
 {
     ros::Rate r(freq);
-    while(nh_->ok())
+    while(nh_.ok())
     {
         cb_queue_.callAvailable();
         r.sleep();

--- a/rgbd/src/server_shm.cpp
+++ b/rgbd/src/server_shm.cpp
@@ -120,13 +120,13 @@ void ServerSHM::send(const Image& image)
 
 // ----------------------------------------------------------------------------------------
 
-void pubHostnameThreadFunc(ros::NodeHandle& nh, const std::string server_name, const std::string hostname, const float frequency)
+void pubHostnameThreadFunc(ros::NodeHandlePtr&& nh, const std::string server_name, const std::string hostname, const float frequency)
 {
-    ros::Publisher pub_shm_hostname = nh.advertise<std_msgs::String>(server_name + "/hosts", 1);
+    ros::Publisher pub_shm_hostname = nh->advertise<std_msgs::String>(server_name + "/hosts", 1);
     ros::Rate r(frequency);
     std_msgs::String msg;
     msg.data = hostname;
-    while(nh.ok())
+    while(nh->ok())
     {
         pub_shm_hostname.publish(msg);
         r.sleep();

--- a/rgbd/src/server_shm.cpp
+++ b/rgbd/src/server_shm.cpp
@@ -120,13 +120,13 @@ void ServerSHM::send(const Image& image)
 
 // ----------------------------------------------------------------------------------------
 
-void pubHostnameThreadFunc(ros::NodeHandlePtr&& nh, const std::string server_name, const std::string hostname, const float frequency)
+void pubHostnameThreadFunc(ros::NodeHandle& nh, const std::string server_name, const std::string hostname, const float frequency)
 {
-    ros::Publisher pub_shm_hostname = nh->advertise<std_msgs::String>(server_name + "/hosts", 1);
+    ros::Publisher pub_shm_hostname = nh.advertise<std_msgs::String>(server_name + "/hosts", 1);
     ros::Rate r(frequency);
     std_msgs::String msg;
     msg.data = hostname;
-    while(nh->ok())
+    while(nh.ok())
     {
         pub_shm_hostname.publish(msg);
         r.sleep();


### PR DESCRIPTION
On HERO we can use a nodelet. This reduces serialization of the ROS Image messages.

I can't test the improvement in the simulator. As the topics are published by Gazebo.

Test instructions:
1. Run `hero-start` and check current CPU/RAM load.
2. Check-out both this repo and `hero_bringup` to the `nodelet` branch and compile.
3. Run `hero-start` and check CPU/RAM load with nodelet.
4. Please report change in CPU/RAM load.