### PR TITLE
use best speed instead of best compression

### DIFF
--- a/rgbd/src/server_rgbd.cpp
+++ b/rgbd/src/server_rgbd.cpp
@@ -69,7 +69,7 @@ void ServerRGBD::send(const Image& image)
     tue::serialization::OutputArchive a(stream);
     serialize(image, a, rgb_type_, depth_type_);
     boost::iostreams::filtering_streambuf<boost::iostreams::input> in;
-    in.push(boost::iostreams::gzip_compressor(boost::iostreams::gzip::best_compression));
+    in.push(boost::iostreams::gzip_compressor(boost::iostreams::gzip::best_speed));
     in.push(stream);
     boost::iostreams::copy(in, stream2);
     tue::serialization::convert(stream2, msg->rgb);


### PR DESCRIPTION
Best compression worked fine with very simple test images, but not with
real world images. It is too heavy and reduces the frequency too much.