### PR TITLE
Use zstd compression

### DIFF
--- a/rgbd/src/ros/conversions.cpp
+++ b/rgbd/src/ros/conversions.cpp
@@ -3,6 +3,7 @@
 #include <boost/iostreams/filtering_streambuf.hpp>
 #include <boost/iostreams/copy.hpp>
 #include <boost/iostreams/filter/gzip.hpp>
+#include <boost/iostreams/filter/zstd.hpp>
 
 #include <cv_bridge/cv_bridge.h>
 
@@ -233,6 +234,17 @@ bool convert(const rgbd_msgs::RGBDConstPtr& msg, rgbd::Image*& image)
         tue::serialization::convert(msg->rgb, compressed);
         boost::iostreams::filtering_streambuf<boost::iostreams::input> in;
         in.push(boost::iostreams::gzip_decompressor());
+        in.push(compressed);
+        boost::iostreams::copy(in, decompressed);
+        tue::serialization::InputArchive a(decompressed);
+        rgbd::deserialize(a, *image);
+    }
+    else if (msg->version == 4)
+    {
+        std::stringstream compressed, decompressed;
+        tue::serialization::convert(msg->rgb, compressed);
+        boost::iostreams::filtering_streambuf<boost::iostreams::input> in;
+        in.push(boost::iostreams::zstd_decompressor());
         in.push(compressed);
         boost::iostreams::copy(in, decompressed);
         tue::serialization::InputArchive a(decompressed);

--- a/rgbd/src/server_rgbd.cpp
+++ b/rgbd/src/server_rgbd.cpp
@@ -2,7 +2,7 @@
 
 #include <boost/iostreams/filtering_streambuf.hpp>
 #include <boost/iostreams/copy.hpp>
-#include <boost/iostreams/filter/gzip.hpp>
+#include <boost/iostreams/filter/zstd.hpp>
 
 #include <opencv2/core/mat.hpp>
 #include <opencv2/imgcodecs.hpp>
@@ -21,7 +21,7 @@
 
 namespace rgbd {
 
-const int ServerRGBD::MESSAGE_VERSION = 3;
+const int ServerRGBD::MESSAGE_VERSION = 4;
 
 // ----------------------------------------------------------------------------------------
 
@@ -70,7 +70,7 @@ void ServerRGBD::send(const Image& image)
     tue::serialization::OutputArchive a(stream);
     serialize(image, a, rgb_type_, depth_type_);
     boost::iostreams::filtering_streambuf<boost::iostreams::input> in;
-    in.push(boost::iostreams::gzip_compressor(boost::iostreams::gzip::best_speed));
+    in.push(boost::iostreams::zstd_compressor(boost::iostreams::zstd::best_speed));
     in.push(stream);
     boost::iostreams::copy(in, stream2);
     tue::serialization::convert(stream2, msg->rgb);


### PR DESCRIPTION
Less CPU load, less BW; Double win

No compression:
  bw: 62 MB/s
  hz: 30 Hz
  cpu: 35%

Current:
  bw: 17 MB/s
  hz: 19 Hz
  cpu: 115%

ztd(1):
  bw: 25 MB/s
  hz: 29,3 Hz
  cpu: 50%

ztd(2):
  bw: 25,5 MB/s
  hz: 29 Hz
  cpu: 61%

ztd(3):
  bw: 24 MB/s
  hz: 28,5 Hz
  cpu: 95%

ztd(4):
  bw: 22 MB/s
  hz: 24,9 Hz
  cpu: 105%